### PR TITLE
PHP Intelephense v1.3.5 - Config Updates

### DIFF
--- a/videos/PHP+WordPress-Setup/settings.json
+++ b/videos/PHP+WordPress-Setup/settings.json
@@ -1,10 +1,12 @@
 {
 	// PHP/WORDPRESS  —————————————————————————————
 	"php.suggest.basic": false,
-	"intelephense.formatProvider.enable": false,
+	"intelephense.format.enable": false,
 	"[php]": {
 		"editor.formatOnSave": false,
-		"editor.formatOnPaste": false
+		"editor.formatOnPaste": false,
+		// PHP Intelephense (Tested in v1.3.5) adds the following line automatically
+		"editor.defaultFormatter": "bmewburn.vscode-intelephense-client"
 	},
 	// PHPCS.
 	"phpcs.executablePath": "/usr/local/bin/phpcs",


### PR DESCRIPTION
• `intelephense.formatProvider.enable` no longer supported in PHP Intelephense _(Tested in v1.3.5)_ and been replaced with `intelephense.format.enable`.
• Adds `"editor.defaultFormatter": "bmewburn.vscode-intelephense-client"` automatically under _"[php]"_ block.